### PR TITLE
Rakefile fix for a Psych error when building the gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,7 @@
 # -*- ruby -*-
 
 require 'rubygems'
+require 'bundler'
 require 'hoe'
 
 require 'rake/extensiontask'


### PR DESCRIPTION
This fixes the error:

```
undefined method `yaml' for #<Psych::Nodes::Stream:0x007fdb74030b18>
```

happening when running `rake gem`.

Env:
- RUBYGEMS VERSION: 1.8.12
- RUBY VERSION: 1.9.2 (2011-07-09 patchlevel 290) [x86_64-darwin11.2.0]
- RVM
- bundler 1.1.rc.7
