### PR TITLE
Fix documentation generation for equalize_hist

### DIFF
--- a/ext/opencv/cvmat.cpp
+++ b/ext/opencv/cvmat.cpp
@@ -5087,7 +5087,7 @@ rb_inpaint(VALUE self, VALUE inpaint_method, VALUE mask, VALUE radius)
 
 /*
  * call-seq:
- *   equalize_hist - cvmat
+ *   equalize_hist -> cvmat
  *
  * Equalize histgram of grayscale of image.
  *


### PR DESCRIPTION
The current documentation (automatically generated by yard) lists an `equalize_hist` method in the search, but when you go to the actual method, it shows `-(cvmat)` as the method name: http://rubydoc.info/github/ruby-opencv/ruby-opencv/master/OpenCV/CvMat:equalize_hist.

The docs with the fix show the method name correctly: http://rubydoc.info/github/gonzedge/ruby-opencv/master/OpenCV/CvMat:equalize_hist.
