### PR TITLE
Morphology documentation

### DIFF
--- a/ext/opencv/cvmat.cpp
+++ b/ext/opencv/cvmat.cpp
@@ -4055,17 +4055,19 @@ rb_dilate_bang(int argc, VALUE *argv, VALUE self)
 }
 
 /*
- * call-seq:
- *   morphology(operation[,element = nil][,iteration = 1]) -> cvmat
+ * Performs advanced morphological transformations using erosion and dilation as basic operations.
  *
- * Performs advanced morphological transformations.
- * <i>operation</i>
- * Type of morphological operation, one of:
- *   CV_MOP_OPEN - opening
- *   CV_MOP_CLOSE - closing
- *   CV_MOP_GRADIENT - morphological gradient
- *   CV_MOP_TOPHAT - top hat
- *   CV_MOP_BLACKHAT - black hat
+ * @overload morphology(operation, element = nil, iteration = 1)
+ * @param operation [Integer] Type of morphological operation.
+ *   * <tt>CV_MOP_OPEN</tt> - Opening
+ *   * <tt>CV_MOP_CLOSE</tt> - Closing
+ *   * <tt>CV_MOP_GRADIENT</tt> - Morphological gradient
+ *   * <tt>CV_MOP_TOPHAT</tt> - Top hat
+ *   * <tt>CV_MOP_BLACKHAT</tt> - Black hat
+ * @param element [IplConvKernel] Structuring element.
+ * @param iteration [Integer] Number of times erosion and dilation are applied.
+ * @return [CvMat] Result array
+ * @opencv_func cvMorphologyEx
  */
 VALUE
 rb_morphology(int argc, VALUE *argv, VALUE self)


### PR DESCRIPTION
This fixes a typo in the `morphology` method documentation as well as adds more detail about the parameters and return type using YARD tags.
