### PR TITLE
fixed segfault of CvSeq by GC

### DIFF
--- a/ext/opencv/cvseq.cpp
+++ b/ext/opencv/cvseq.cpp
@@ -56,7 +56,7 @@ VALUE
 rb_allocate(VALUE klass)
 {
   CvSeq *ptr = ALLOC(CvSeq);
-  return Data_Wrap_Struct(klass, 0, unregister_elem_class, ptr);
+  return Data_Wrap_Struct(klass, mark_root_object, unregister_elem_class, ptr);
 }
 
 CvSeq*


### PR DESCRIPTION
はじめまして、さたけよしかずと申します。ruby-opencv、便利に使わせていただいております。

手元の環境(Debian Jessie amd64)で、CvSeqにCvPointを追加していくと状況によりsegfaultする問題が発生するので、調査、修正してみました。

原因としては、GCされてしまったオブジェクトを参照しているというものでした。(作業を行ったのが結構以前で、ちょっと詳細が出てきません。すみません。)

修正をmasterに取り込んでいただけるとありがたいです。どうぞ、よろしくお願いいたします。