### PR TITLE
Ruby 2.4 fixes regarding Fixnum deprecation

### DIFF
--- a/ext/opencv/cvcapture.cpp
+++ b/ext/opencv/cvcapture.cpp
@@ -39,7 +39,7 @@ cvcapture_free(void *ptr)
  * Open video file or a capturing device for video capturing
  * @scope class
  * @overload open(dev = nil)
- *   @param dev [String,Fixnum,Simbol,nil] Video capturing device
+ *   @param dev [String,Integer,Simbol,nil] Video capturing device
  *     * If dev is a string (i.e "stream.avi"), reads video stream from a file.
  *     * If dev is a number or symbol (included in CvCapture::INTERFACE), reads video stream from a device.
  *     * If dev is a nil, same as CvCapture.open(:any)

--- a/ext/opencv/cvchain.cpp
+++ b/ext/opencv/cvchain.cpp
@@ -62,7 +62,7 @@ rb_initialize(int argc, VALUE *argv, VALUE self)
     raise_cverror(e);
   }
   CvSeq* self_ptr = CVSEQ(self);
-  cCvSeq::register_elem_class(self_ptr, rb_cFixnum);
+  cCvSeq::register_elem_class(self_ptr, rb_cInteger);
   register_root_object(self_ptr, storage_value);
 
   return self;

--- a/ext/opencv/cvchain.cpp
+++ b/ext/opencv/cvchain.cpp
@@ -95,7 +95,7 @@ rb_set_origin(VALUE self, VALUE origin)
 /*
  * Returns the chain codes
  * @overload codes
- * @return [Array<Fixnum>] Chain codes
+ * @return [Array<Integer>] Chain codes
  * @opencv_func cvStartReadChainPoints
  * @opencv_func CV_READ_SEQ_ELEM
  */

--- a/ext/opencv/cvcontour.cpp
+++ b/ext/opencv/cvcontour.cpp
@@ -44,14 +44,14 @@ rb_allocate(VALUE klass)
  * Constructor
  *
  * @overload new(seq_flags = CV_SEQ_ELTYPE_POINT | CV_SEQ_KIND_GENERIC, storage = nil)
- *   @param [Fixnum] seq_flags Flags of the created sequence, which are combinations of
+ *   @param [Integer] seq_flags Flags of the created sequence, which are combinations of
  *     the element types and sequence types.
  *     - Element type:
  *       - <tt>CV_SEQ_ELTYPE_POINT</tt>: {CvPoint}
  *       - <tt>CV_32FC2</tt>: {CvPoint2D32f}
  *       - <tt>CV_SEQ_ELTYPE_POINT3D</tt>: {CvPoint3D32f}
- *       - <tt>CV_SEQ_ELTYPE_INDEX</tt>: Fixnum
- *       - <tt>CV_SEQ_ELTYPE_CODE</tt>: Fixnum (Freeman code)
+ *       - <tt>CV_SEQ_ELTYPE_INDEX</tt>: Integer
+ *       - <tt>CV_SEQ_ELTYPE_CODE</tt>: Integer (Freeman code)
  *     - Sequence type:
  *       - <tt>CV_SEQ_KIND_GENERIC</tt>: Generic sequence
  *       - <tt>CV_SEQ_KIND_CURVE</tt>: Curve

--- a/ext/opencv/cvfont.cpp
+++ b/ext/opencv/cvfont.cpp
@@ -108,7 +108,7 @@ rb_initialize(int argc, VALUE *argv, VALUE self)
 /*
  * Returns font face
  * @overload face
- * @return [Fixnum] Font face
+ * @return [Integer] Font face
  */
 VALUE
 rb_face(VALUE self)
@@ -152,7 +152,7 @@ rb_shear(VALUE self)
 /*
  * Returns thickness
  * @overload thickness
- * @return [Fixnum] thickness
+ * @return [Integer] thickness
  */
 VALUE
 rb_thickness(VALUE self)
@@ -163,7 +163,7 @@ rb_thickness(VALUE self)
 /*
  * Returns line type
  * @overload line_type
- * @return [Fixnum] line_type
+ * @return [Integer] line_type
  */
 VALUE
 rb_line_type(VALUE self)

--- a/ext/opencv/cvpoint.cpp
+++ b/ext/opencv/cvpoint.cpp
@@ -12,7 +12,7 @@
  * Document-class: OpenCV::CvPoint
  *
  * This class means one point on X axis Y axis. 
- * X and Y takes the value of the Fixnum. see also CvPoint2D32F
+ * X and Y takes the value of the Integer. see also CvPoint2D32F
  * 
  * C structure is here, very simple.
  *   typdef struct CvPoint {

--- a/ext/opencv/cvscalar.cpp
+++ b/ext/opencv/cvscalar.cpp
@@ -53,7 +53,7 @@ rb_allocate(VALUE klass)
  * call-seq:
  *   new([d1][,d2][,d3][,d4])
  *
- * Create new Scalar. Argument should be Fixnum (or nil as 0).
+ * Create new Scalar. Argument should be Integer (or nil as 0).
  */
 VALUE
 rb_initialize(int argc, VALUE *argv, VALUE self)

--- a/ext/opencv/cvseq.cpp
+++ b/ext/opencv/cvseq.cpp
@@ -146,14 +146,14 @@ class2seq_flags_value(VALUE klass) {
  * Constructor
  *
  * @overload new(seq_flags, storage = nil)
- *   @param [Fixnum] seq_flags Flags of the created sequence, which are combinations of
+ *   @param [Integer] seq_flags Flags of the created sequence, which are combinations of
  *     the element types and sequence types.
  *     - Element type:
  *       - <tt>CV_SEQ_ELTYPE_POINT</tt>: {CvPoint}
  *       - <tt>CV_32FC2</tt>: {CvPoint2D32f}
  *       - <tt>CV_SEQ_ELTYPE_POINT3D</tt>: {CvPoint3D32f}
- *       - <tt>CV_SEQ_ELTYPE_INDEX</tt>: Fixnum
- *       - <tt>CV_SEQ_ELTYPE_CODE</tt>: Fixnum (Freeman code)
+ *       - <tt>CV_SEQ_ELTYPE_INDEX</tt>: Integer
+ *       - <tt>CV_SEQ_ELTYPE_CODE</tt>: Integer (Freeman code)
  *     - Sequence type:
  *       - <tt>CV_SEQ_KIND_GENERIC</tt>: Generic sequence
  *       - <tt>CV_SEQ_KIND_CURVE</tt>: Curve

--- a/ext/opencv/cvseq.cpp
+++ b/ext/opencv/cvseq.cpp
@@ -43,7 +43,7 @@ eltype2class(int eltype, VALUE* ret) {
     break;
   case CV_SEQ_ELTYPE_CODE:
   case CV_SEQ_ELTYPE_INDEX:
-    *ret = rb_cFixnum;
+    *ret = rb_cInteger;
     break;
   case CV_SEQ_ELTYPE_PPOINT: // or CV_SEQ_ELTYPE_PTR:
     // Not supported
@@ -132,7 +132,7 @@ class2seq_flags_value(VALUE klass) {
   else if (klass == cCvPoint3D32f::rb_class()) {
     seq_flags = CV_SEQ_ELTYPE_POINT3D;
   }
-  else if (klass == rb_cFixnum) {
+  else if (klass == rb_cInteger) {
     seq_flags = CV_SEQ_ELTYPE_INDEX;
   }
   else {
@@ -421,7 +421,7 @@ rb_pop(VALUE self)
   VALUE object = Qnil;
   VALUE klass = seqblock_class(seq);
   try {
-    if (klass == rb_cFixnum) {
+    if (klass == rb_cInteger) {
       int n = 0;
       cvSeqPop(seq, &n);
       object = INT2FIX(n);
@@ -489,7 +489,7 @@ rb_shift(VALUE self)
 
   VALUE object = Qnil;
   try {
-    if (seqblock_class(seq) == rb_cFixnum) {
+    if (seqblock_class(seq) == rb_cInteger) {
       int n = 0;
       cvSeqPopFront(seq, &n);
       object = INT2NUM(n);
@@ -525,7 +525,7 @@ rb_each(VALUE self)
   if (seq->total > 0) {
     VALUE klass = seqblock_class(seq);
     try {
-      if (klass == rb_cFixnum)
+      if (klass == rb_cInteger)
 	for (int i = 0; i < seq->total; ++i)
 	  rb_yield(INT2NUM(*CV_GET_SEQ_ELEM(int, seq, i)));
       else
@@ -570,7 +570,7 @@ rb_insert(VALUE self, VALUE index, VALUE object)
   if (CLASS_OF(object) != klass)
     rb_raise(rb_eTypeError, "arguments should be %s.", rb_class2name(klass));
   try {
-    if (klass == rb_cFixnum) {
+    if (klass == rb_cInteger) {
       int n = NUM2INT(object);
       cvSeqInsert(seq, NUM2INT(index), &n);
     }

--- a/ext/opencv/cvseq.cpp
+++ b/ext/opencv/cvseq.cpp
@@ -567,7 +567,7 @@ rb_insert(VALUE self, VALUE index, VALUE object)
   Check_Type(index, T_FIXNUM);
   CvSeq *seq = CVSEQ(self);
   VALUE klass = seqblock_class(seq);
-  if (CLASS_OF(object) != klass)
+  if (!rb_obj_is_kind_of(object, klass))
     rb_raise(rb_eTypeError, "arguments should be %s.", rb_class2name(klass));
   try {
     if (klass == rb_cInteger) {

--- a/ext/opencv/cvsize.cpp
+++ b/ext/opencv/cvsize.cpp
@@ -12,7 +12,7 @@
  * Document-class: OpenCV::CvSize
  *
  * This class means one size on X axis Y axis. 
- * X and Y takes the value of the Fixnum.
+ * X and Y takes the value of the Integer.
  * 
  * C structure is here, very simple.
  *   typdef struct CvSize {

--- a/ext/opencv/cvtwopoints.cpp
+++ b/ext/opencv/cvtwopoints.cpp
@@ -12,7 +12,7 @@
  * Document-class: OpenCV::CvTwoPoints
  *
  * This class means one twopoints on X axis Y axis. 
- * X and Y takes the value of the Fixnum. see also CvTwopoints2D32F
+ * X and Y takes the value of the Integer. see also CvTwopoints2D32F
  * 
  * C structure is here, very simple.
  *   typdef struct CvTwopoints {

--- a/ext/opencv/iplimage.cpp
+++ b/ext/opencv/iplimage.cpp
@@ -193,7 +193,7 @@ rb_reset_roi(VALUE self)
 }
 
 /*
- * Return COI as Fixnum.
+ * Return COI as Integer.
  */
 VALUE
 rb_get_coi(VALUE self)
@@ -213,7 +213,7 @@ rb_get_coi(VALUE self)
  *   set_coi(coi)
  *   set_coi(coi){|image| ...}
  *
- * Set COI. <i>coi</i> should be Fixnum.
+ * Set COI. <i>coi</i> should be Integer.
  * Return self.
  */
 VALUE

--- a/ext/opencv/trackbar.cpp
+++ b/ext/opencv/trackbar.cpp
@@ -47,7 +47,7 @@ void trackbar_free(void *ptr) {
  *
  * Create new Trackbar.
  * <i>name</i> should be String.
- * <i>maxval</i> and <i>val</i> should be Fixnum.
+ * <i>maxval</i> and <i>val</i> should be Integer.
  * When Trackbar adjuster changed, block will be called.
  */
 VALUE rb_initialize(int argc, VALUE *argv, VALUE self) {

--- a/test/test_cvavgcomp.rb
+++ b/test/test_cvavgcomp.rb
@@ -18,7 +18,7 @@ class TestCvAvgComp < OpenCVTestCase
   end
 
   def test_neighbors
-    assert_equal(Fixnum, @avgcomp.neighbors.class)
+    assert_kind_of(Integer, @avgcomp.neighbors)
   end
 end
 

--- a/test/test_cvchain.rb
+++ b/test/test_cvchain.rb
@@ -42,7 +42,7 @@ class TestCvChain < OpenCVTestCase
     }
     chain = mat0.find_contours(:mode => CV_RETR_EXTERNAL, :method => CV_CHAIN_CODE)
     assert_equal(Array, chain.codes.class)
-    assert(chain.codes.all? { |a| (a.class == Fixnum) and (a >= 0 and a <= 7) })
+    assert(chain.codes.all? { |a| (Integer === a) and (a >= 0 and a <= 7) })
   end
 
   def test_points

--- a/test/test_cvseq.rb
+++ b/test/test_cvseq.rb
@@ -67,7 +67,7 @@ class TestCvSeq < OpenCVTestCase
     
     seq2 = CvSeq.new(CV_SEQ_ELTYPE_INDEX)
     seq2.push(10, 20, 30)
-    assert_equal(Fixnum, seq2[0].class)
+    assert_kind_of(Integer, seq2[0])
     assert_equal(10, seq2[0])
     assert_equal(20, seq2[1])
     assert_equal(30, seq2[2])
@@ -101,7 +101,7 @@ class TestCvSeq < OpenCVTestCase
     seq4 = CvSeq.new(CV_SEQ_ELTYPE_INDEX).push(20, 30)
     seq3.push(seq4)
     assert_equal(3, seq3.total)
-    assert_equal(Fixnum, seq3[0].class)
+    assert_kind_of(Integer, seq3[0])
     assert_equal(10, seq3[0])
     assert_equal(20, seq3[1])
     assert_equal(30, seq3[2])


### PR DESCRIPTION
I'm not entirely sure about the last commit, because I don't know CvSeq well.