### PR TITLE
Add continuous integration with Travis CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,32 @@
+language: ruby
+
+sudo: false
+
+dist: trusty
+
+rvm:
+  - 2.3.4
+  - 2.4.1
+
+addons:
+  apt:
+    packages:
+      - libopencv-dev
+
+env:
+  global:
+    - PATH=/usr/lib/ccache:$PATH
+
+cache:
+  bundler: true
+  directories:
+    - $HOME/.ccache
+
+before_script:
+  - ruby ext/opencv/extconf.rb
+  - make
+  - make install
+
+script:
+  - cd test
+  - ruby runner.rb

--- a/README.md
+++ b/README.md
@@ -1,3 +1,5 @@
+![Build Status with Travis CI](https://travis-ci.org/ruby-opencv/ruby-opencv.svg?branch=master)
+
 # ruby-opencv
 
 An OpenCV wrapper for Ruby.


### PR DESCRIPTION
This PR adds CI with [Travis CI](https://travis-ci.org).

To use, please activate Travis CI on this repository following these easy steps: https://docs.travis-ci.com/user/getting-started#To-get-started-with-Travis-CI%3A

Steps 3 and 4 can be replaced by merging this PR.

You can see how it is working right now on my fork: https://travis-ci.org/BanzaiMan/ruby-opencv/builds/236004008